### PR TITLE
Add RapidAPI config and fetch logic

### DIFF
--- a/cloud_security_scout/frontend/README.md
+++ b/cloud_security_scout/frontend/README.md
@@ -1,0 +1,16 @@
+# Cloud Security Scout Frontend
+
+This directory contains the Vite based React application used for the Cloud Security Scout demo.
+
+## Development
+
+Navigate into the `y` directory and copy `.env.example` to `.env` before starting the development server:
+
+```bash
+cd y
+cp .env.example .env
+# Edit .env and set VITE_RAPIDAPI_KEY
+npm run dev
+```
+
+The `VITE_RAPIDAPI_KEY` must be a valid API key for the imdb236 API. The host value is already provided in the example file.

--- a/cloud_security_scout/frontend/y/.env.example
+++ b/cloud_security_scout/frontend/y/.env.example
@@ -1,0 +1,2 @@
+VITE_RAPIDAPI_KEY=
+VITE_RAPIDAPI_HOST=imdb236.p.rapidapi.com


### PR DESCRIPTION
## Summary
- add `.env.example` with RapidAPI values
- fetch movie data from imdb236 RapidAPI in `MovieDashboard`
- document frontend setup with environment variables

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68534fe4830c83309d2766a06aa9359f