### PR TITLE
Add SecurityScoutRecord schema

### DIFF
--- a/cloud_security_scout/security_scout/security_scout_dynamodb.ts
+++ b/cloud_security_scout/security_scout/security_scout_dynamodb.ts
@@ -1,0 +1,10 @@
+export interface SecurityScoutRecord {
+  id: string;                      // Partition key
+  timestamp: number;              // Sort key
+  securityStatus?: string;        // Indexed by GSI
+  expiresAt?: number;             // TTL attribute (epoch time)
+  region?: string;                // Optional: AWS region where scan happened
+  resourceType?: string;          // Optional: e.g., S3, RDS, EC2
+  issueType?: string;             // Optional: Type of security finding
+  description?: string;           // Optional: Finding summary
+}


### PR DESCRIPTION
## Summary
- define `SecurityScoutRecord` interface for DynamoDB records

## Testing
- `npm test --silent` in `cloud_security_scout/security_scout`
- `npm test --silent` in `secure-file-vault`


------
https://chatgpt.com/codex/tasks/task_e_6853d1f108688330ab216a385b6ac143